### PR TITLE
Fix light system; Use std::span to read light data

### DIFF
--- a/BansheeEngine/BansheeEngine/Source/Graphics/Systems/LightSystem.cpp
+++ b/BansheeEngine/BansheeEngine/Source/Graphics/Systems/LightSystem.cpp
@@ -4,26 +4,40 @@
 
 namespace Banshee
 {
-	void LightSystem::ProcessComponents(const Entity* const _entity)
-	{
+    void LightSystem::ProcessComponents(const Entity* const _entity)
+    {
         if (const auto lightComponent = _entity->GetComponent<LightComponent>())
         {
-            AddLightComponent(*lightComponent);
+            AddLightComponent(lightComponent);
         }
-	}
+    }
 
-    void LightSystem::AddLightComponent(const LightComponent& _lightComponent)
+    void LightSystem::AddLightComponent(const std::shared_ptr<LightComponent>& _lightComponent)
     {
         m_LightComponents.emplace_back(_lightComponent);
 
-        if (!_lightComponent.IsDirectionalLight())
+        if (_lightComponent->IsDirectionalLight() && !m_DirectionalLight.has_value())
         {
-            return;
-        }
-
-        if (!m_DirectionalLight.has_value())
-        {
-            m_DirectionalLight = static_cast<const DirectionalLightComponent&>(_lightComponent);
+            m_DirectionalLight = std::static_pointer_cast<DirectionalLightComponent>(_lightComponent);
         }
     }
-} // End of namespace
+
+    std::array<LightData, LightSystem::MaxLights> LightSystem::UpdateLightData(uint8& _outLightCount) const noexcept
+    {
+        std::array<LightData, MaxLights> lights{};
+        _outLightCount = 0;
+
+        for (const auto& lightComponent : m_LightComponents)
+        {
+            if (_outLightCount >= MaxLights)
+            {
+                break;
+            }
+
+            lightComponent->UpdatePosition();
+            lights[_outLightCount++] = lightComponent->GetLightData();
+        }
+
+        return lights;
+    }
+} // namespace Banshee

--- a/BansheeEngine/BansheeEngine/Source/Graphics/Systems/LightSystem.h
+++ b/BansheeEngine/BansheeEngine/Source/Graphics/Systems/LightSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <vector>
 #include <optional>
 #include "Graphics/Components/Light/LightComponent.h"
@@ -12,23 +13,25 @@ namespace Banshee
     class LightSystem
     {
     public:
+        static constexpr uint8 MaxLights{ 25 };
+
         LightSystem() noexcept = default;
         ~LightSystem() noexcept = default;
-
-        void ProcessComponents(const Entity* const _entity);
-        std::vector<LightComponent>& GetLightComponents() noexcept { return m_LightComponents; }
-        const std::optional<DirectionalLightComponent>& GetDirectionalLight() const noexcept { return m_DirectionalLight; }
 
         LightSystem(const LightSystem&) = delete;
         LightSystem& operator=(const LightSystem&) = delete;
         LightSystem(LightSystem&&) = delete;
         LightSystem& operator=(LightSystem&&) = delete;
 
-    private:
-        void AddLightComponent(const LightComponent& _lightComponent);
+        void ProcessComponents(const Entity* const _entity);
+        std::array<LightData, MaxLights> UpdateLightData(uint8& outLightCount) const noexcept;
+        [[nodiscard]] const std::optional<std::shared_ptr<DirectionalLightComponent>>& GetDirectionalLight() const noexcept { return m_DirectionalLight; }
 
     private:
-        std::vector<LightComponent> m_LightComponents;
-        std::optional<DirectionalLightComponent> m_DirectionalLight;
+        void AddLightComponent(const std::shared_ptr<LightComponent>& lightComponent);
+
+    private:
+        std::vector<std::shared_ptr<LightComponent>> m_LightComponents;
+        std::optional<std::shared_ptr<DirectionalLightComponent>> m_DirectionalLight;
     };
-} // End of namespace
+} // namespace Banshee

--- a/BansheeEngine/BansheeEngine/Source/Graphics/Vulkan/SceneData/VulkanSceneResources.cpp
+++ b/BansheeEngine/BansheeEngine/Source/Graphics/Vulkan/SceneData/VulkanSceneResources.cpp
@@ -94,6 +94,15 @@ namespace Banshee
 		m_LightSpaceUniformBuffer.CopyData(&_lightSpaceMatrix);
 	}
 
+	void VulkanSceneResources::UpdateLightUniformBuffer(std::span<const LightData> _lightData, const uint32 _currentFrameIndex)
+	{
+		LightBuffer lightBuffer{};
+		lightBuffer.m_TotalLights = static_cast<uint8>(_lightData.size());
+
+		std::copy(_lightData.begin(), _lightData.end(), lightBuffer.m_Lights);
+		m_LightUniformBuffers.at(_currentFrameIndex).CopyData(&lightBuffer);
+	}
+
 	void VulkanSceneResources::SetSceneTextures(const std::vector<VkImageView>& _textureViews, const VkSampler& _sampler)
 	{
 		m_DescriptorSetTextureWriters.at(0).SetImageView(_textureViews);
@@ -117,30 +126,5 @@ namespace Banshee
 		{
 			m_DescriptorSets.at(i).UpdateDescriptorSet(m_DescriptorSetTextureWriters);
 		}
-	}
-
-	void VulkanSceneResources::UpdateLightData(LightSystem& _lightSystem, const uint32 _currentFrameIndex)
-	{
-		constexpr uint8 maxLights{ 25 };
-		std::array<LightData, maxLights> lights{};
-		uint8 currentLightCount{ 0 };
-
-		for (auto& lightComponent : _lightSystem.GetLightComponents())
-		{
-			if (currentLightCount >= maxLights)
-			{
-				break;
-			}
-
-			lightComponent.UpdatePosition();
-			lights.at(currentLightCount++) = lightComponent.GetLightData();
-		}
-
-		LightBuffer lightBuffer{};
-		lightBuffer.m_TotalLights = currentLightCount;
-
-		std::copy(lights.begin(), lights.begin() + currentLightCount, lightBuffer.m_Lights);
-
-		m_LightUniformBuffers.at(_currentFrameIndex).CopyData(&lightBuffer);
 	}
 } // End of namespace

--- a/BansheeEngine/BansheeEngine/Source/Graphics/Vulkan/SceneData/VulkanSceneResources.h
+++ b/BansheeEngine/BansheeEngine/Source/Graphics/Vulkan/SceneData/VulkanSceneResources.h
@@ -7,8 +7,10 @@
 #include "Graphics/Vulkan/VulkanUniformBuffer.h"
 #include "Graphics/Vulkan/VulkanDescriptorSet.h"
 #include "Graphics/Vulkan/VulkanDescriptorSetWriters.h"
+#include "Graphics/Components/Light/LightData.h"
 #include <glm/glm.hpp>
 #include <memory>
+#include <span> 
 
 typedef struct VkSampler_T* VkSampler;
 
@@ -17,7 +19,6 @@ namespace Banshee
 	class VulkanRenderContext;
 	class Material;
 	class MeshSystem;
-	class LightSystem;
 	struct ViewProjMatrix;
 
 	class VulkanSceneResources
@@ -28,6 +29,7 @@ namespace Banshee
 		void UpdateMeshUniformBuffers(const MeshSystem& _meshSystem);
 		void UpdateVPUniformBuffers(ViewProjMatrix& _viewProj, const uint32 _imgIndex) const;
 		void UpdateLightSpaceUniformBuffer(glm::mat4& _lightSpaceMatrix) const noexcept;
+		void UpdateLightUniformBuffer(std::span<const LightData> _lightData, const uint32 _currentFrameIndex);
 		void SetSceneTextures(const std::vector<VkImageView>& _textureViews, const VkSampler& _sampler);
 		void SetSceneShadowMap(const VkImageView& _shadowMapView, const VkSampler& _sampler);
 		void RecreateDepthBuffer(const uint32 _w, const uint32 _h, const uint32 _flags);
@@ -37,7 +39,6 @@ namespace Banshee
 		const VkRenderPass& GetRenderPass() const noexcept { return m_RenderPass.Get(); }
 		const VulkanSceneDescriptorSetLayout& GetDescriptorSetLayout() const noexcept { return m_DescriptorSetLayout; }
 		const VulkanGraphicsPipeline& GetPipeline() const noexcept { return m_Pipeline; }
-		void UpdateLightData(LightSystem& _lightSystem, const uint32 _currentFrameIndex);
 		std::vector<VulkanDescriptorSet>& GetDescriptorSets() noexcept { return m_DescriptorSets; }
 		uint64 GetMaterialMemoryAlignment() const noexcept { return m_MaterialDynamicBufferMemAlignment; }
 

--- a/BansheeEngine/BansheeEngine/Source/Graphics/Vulkan/SceneData/VulkanSceneShadowResources.cpp
+++ b/BansheeEngine/BansheeEngine/Source/Graphics/Vulkan/SceneData/VulkanSceneShadowResources.cpp
@@ -29,7 +29,7 @@ namespace Banshee
 			return;
 		}
 
-		const glm::vec3 lightDir{ glm::normalize(directionalLightComponent->GetLightData().m_Direction) };
+		const glm::vec3 lightDir{ glm::normalize(directionalLightComponent->get()->GetLightData().m_Direction)};
 		const glm::vec3 lightPos{ -lightDir * 10.0f };
 		const glm::mat4 lightViewMatrix{ glm::lookAt(lightPos, glm::vec3(0.0f), glm::vec3(0.0f, 1.0f, 0.0f)) };
 		const glm::mat4 lightProjMatrix{ glm::ortho(-20.0f, 20.0f, -20.0f, 20.0f, 0.1f, 50.0f) };

--- a/BansheeEngine/BansheeEngine/Source/Graphics/Vulkan/VulkanRenderer.cpp
+++ b/BansheeEngine/BansheeEngine/Source/Graphics/Vulkan/VulkanRenderer.cpp
@@ -163,7 +163,11 @@ namespace Banshee
 		ViewProjMatrix viewProjMatrix{ m_Camera.GetViewProjMatrix() };
 		viewProjMatrix.m_Proj[1][1] *= -1.0f;
 		m_SceneResources.UpdateVPUniformBuffers(viewProjMatrix, _imgIndex);
-		m_SceneResources.UpdateLightData(m_LightSystem, m_CurrentFrameIndex);
+
+		uint8 lightCount{ 0 };
+		auto lightData{ m_LightSystem.UpdateLightData(lightCount) };
+		m_SceneResources.UpdateLightUniformBuffer(std::span{ lightData }.first(lightCount), _imgIndex);
+
 		m_SceneResources.UpdateDescriptorSets(_imgIndex);
 
 		RenderScene(cmdBuffer, _imgIndex);

--- a/BansheeEngine/Sandbox/Source/ExampleScene.h
+++ b/BansheeEngine/Sandbox/Source/ExampleScene.h
@@ -25,28 +25,22 @@ private:
 	std::shared_ptr<CustomMeshComponent> m_MeshComp;
 };
 
-class ExamplePrimitiveModel : public Entity
-{
-public:
-	explicit ExamplePrimitiveModel(const glm::vec3& _pos = glm::vec3(0.0f))
-	{
-		auto meshComponent{ AddComponent<PrimitiveMeshComponent>(PrimitiveShapeEnum::CubeShape, ShaderTypeEnum::Standard) };
-		meshComponent->SetTexture("Textures/tiles.jpg");
-		m_Transform = AddComponent<TransformComponent>();
-		m_Transform->SetPosition(_pos);
-	}
-
-private:
-	std::shared_ptr<TransformComponent> m_Transform;
-};
-
 class ExampleCube : public Entity
 {
 public:
-	explicit ExampleCube(const glm::vec3& _pos = glm::vec3(0.0f))
+	ExampleCube(const glm::vec3& _pos = glm::vec3(0.0f), const glm::vec3& _tintColor = glm::vec3(1.0f), const char* _texturePath = nullptr)
 	{
 		auto meshComponent{ AddComponent<PrimitiveMeshComponent>(PrimitiveShapeEnum::CubeShape, ShaderTypeEnum::Standard) };
-		meshComponent->SetTexture("Textures/tiles.jpg");
+
+		if (_texturePath)
+		{
+			meshComponent->SetTexture(_texturePath);
+		}
+		else
+		{
+			meshComponent->SetTintColor(glm::vec4(_tintColor.x, _tintColor.y, _tintColor.z, 1.0f));
+		}
+
 		m_Transform = AddComponent<TransformComponent>();
 		m_Transform->SetPosition(_pos);
 	}
@@ -54,6 +48,11 @@ public:
 	void SetPosition(const glm::vec3& _pos)
 	{
 		m_Transform->SetPosition(_pos);
+	}
+
+	void SetScale(const float _scale)
+	{
+		m_Transform->SetScale(glm::vec3(_scale));
 	}
 
 private:
@@ -69,7 +68,7 @@ public:
 		meshComponent->SetTintColor(glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
 		m_Transform = AddComponent<TransformComponent>();
 		m_Transform->SetPosition(_pos);
-		m_Transform->SetScale(glm::vec3(15.0f, 15.0f, 1.0f));
+		m_Transform->SetScale(glm::vec3(10.0f, 10.0f, 1.0f));
 		m_Transform->SetRotation(glm::quat(glm::vec3(glm::radians(-90.0f), 0.0f, 0.0f)));
 	}
 

--- a/BansheeEngine/Sandbox/Source/PointLight.h
+++ b/BansheeEngine/Sandbox/Source/PointLight.h
@@ -11,10 +11,11 @@ class PointLight : public Entity
 public:
 	PointLight(const glm::vec3& _pos = glm::vec3(1.0f), const glm::vec4& _color = glm::vec4(1.0f), const float _radius = 10.0f)
 	{
-		auto meshComp{ AddComponent<PrimitiveMeshComponent>(PrimitiveShapeEnum::CubeShape, ShaderTypeEnum::Unlit) };
+		auto meshComp{ AddComponent<PrimitiveMeshComponent>(PrimitiveShapeEnum::CubeShape, ShaderTypeEnum::Standard) };
 		meshComp->SetTintColor(glm::vec4(_color.x, _color.y, _color.z, 1.0f));
 		AddComponent<PointLightComponent>(_color, _radius);
 		m_Transform = AddComponent<TransformComponent>();
+		m_Transform->SetScale(glm::vec3(0.5f));
 		m_Transform->SetPosition(_pos);
 	}
 

--- a/BansheeEngine/Sandbox/Source/main.cpp
+++ b/BansheeEngine/Sandbox/Source/main.cpp
@@ -1,27 +1,20 @@
 #include "ExampleScene.h"
 #include "DirectionalLight.h"
+#include "PointLight.h"
 #include <Banshee.h>
-#include <array>
 
 class ClientApp : public Banshee::Application
 {
 public:
 	ClientApp() :
-		m_DirectionalLight{ glm::vec3(0.5f, -0.5f, -1.0f), glm::vec4(1.0f, 1.0f, 1.0f, 1.0f) },
-		m_Ground{},
-		m_CustomModel{ glm::vec3(0.0f, 1.0f, 0.0f) }
+		m_DirectionalLight{ glm::vec3(-0.3f, -1.0f, -0.5f), glm::vec4(1.0f, 0.95f, 0.9f, 0.25f) },
+		m_Ground{ glm::vec3(0.0f, 0.0f, 0.0f) },
+		m_CustomModel{ glm::vec3(0.0f, 1.0f, 0.0f) },
+		m_PointLightRed{ glm::vec3(-2.0f, 0.5f, -1.5f), glm::vec4(1.0f, 0.2f, 0.2f, 2.0f) },
+		m_PointLightGreen{ glm::vec3(2.0f, 0.5f, 0.5f), glm::vec4(0.2f, 1.0f, 0.2f, 2.0f) },
+		m_PointLightBlue{ glm::vec3(0.0f, 0.5f, 2.0f), glm::vec4(0.2f, 0.2f, 1.0f, 2.0f) }
 	{
-		const std::array<glm::vec3, 3> cubePositions
-		{
-			glm::vec3(-4.0f, 0.5f, -1.0f),
-			glm::vec3(5.0f, 1.0f, 1.0f),
-			glm::vec3(2.0f, 0.5f, 5.0f)
-		};
-
-		for (size_t i = 0; i < m_Cubes.size(); ++i)
-		{
-			m_Cubes[i].SetPosition(cubePositions[i]);
-		}
+		m_CustomModel.SetTintColor(glm::vec4(1.0f, 0.8f, 0.3f, 1.0f));
 	}
 
 	ClientApp(const ClientApp&) = delete;
@@ -33,7 +26,9 @@ private:
 	DirectionalLight m_DirectionalLight;
 	ExampleQuad m_Ground;
 	ExampleCustomModel m_CustomModel;
-	std::array<ExampleCube, 3> m_Cubes;
+	PointLight m_PointLightRed;
+	PointLight m_PointLightGreen;
+	PointLight m_PointLightBlue;
 };
 
 std::unique_ptr<Banshee::Application> CreateApplication()


### PR DESCRIPTION
Moved the light calculations into the light system instead of SceneResources
To allow for polymorphic behavior, had to store the light components as shared pointers in the light system